### PR TITLE
WaterBathテーブルのCRUD機能作成 およびFacilityテーブルとの関連付け

### DIFF
--- a/app/controllers/facilities_controller.rb
+++ b/app/controllers/facilities_controller.rb
@@ -8,6 +8,7 @@ class FacilitiesController < ApplicationController
   def new
     @facility = Facility.new
     @facility.saunas.build
+    @facility.water_baths.build
   end
 
   def create
@@ -22,11 +23,13 @@ class FacilitiesController < ApplicationController
   def show
     @facility = Facility.find(params[:id])
     @saunas = @facility.saunas
+    @water_baths = @facility.water_baths
   end
 
   def edit
     @facility = Facility.find(params[:id])
     @facility.saunas.build
+    @facility.water_baths.build
   end
 
   def update
@@ -50,7 +53,8 @@ class FacilitiesController < ApplicationController
                                      :homepage, :business_hours, :holiday,
                                      :fee, :payment, :comment,
                                      saunas_attributes: [
-                                       :id, :sex , :temperature, :intern, :comment
-                                     ])
+                                       :id, :sex , :temperature, :intern, :comment],
+                                     water_baths_attributes: [
+                                      :id, :sex , :temperature, :intern, :comment])
   end
 end

--- a/app/models/facility.rb
+++ b/app/models/facility.rb
@@ -3,4 +3,5 @@ class Facility < ApplicationRecord
   has_many :saunas, dependent: :destroy
   has_many :water_baths, dependent: :destroy
   accepts_nested_attributes_for :saunas, allow_destroy: true, reject_if: :all_blank
+  accepts_nested_attributes_for :water_baths, allow_destroy: true, reject_if: :all_blank
 end

--- a/app/models/facility.rb
+++ b/app/models/facility.rb
@@ -1,5 +1,6 @@
 class Facility < ApplicationRecord
   has_many :reviews, dependent: :destroy
   has_many :saunas, dependent: :destroy
+  has_many :water_baths, dependent: :destroy
   accepts_nested_attributes_for :saunas, allow_destroy: true, reject_if: :all_blank
 end

--- a/app/models/water_bath.rb
+++ b/app/models/water_bath.rb
@@ -1,0 +1,4 @@
+class WaterBath < ApplicationRecord
+  belongs_to :facility
+  enum sex: { "無性別": 0, "男性": 1, "女性": 2 }
+end

--- a/app/views/facilities/_form.html.erb
+++ b/app/views/facilities/_form.html.erb
@@ -59,5 +59,27 @@
       <%= sauna.text_area :comment %>
     </div>
   <% end %>
+
+  <h2>水風呂情報</h2>
+  <%= form.fields_for :water_baths do |water| %>
+    <div class="water_field">
+      <%= water.label :sex ,"男性" %>
+      <%= water.radio_button :sex, :"男性" %>
+      <%= water.label :sex ,"女性" %>
+      <%= water.radio_button :sex, :"女性" %>
+    </div>
+    <div class="water_field">
+      <%= water.label :temperature ,"温度" %><br>
+      <%= water.number_field :temperature %>
+    </div>
+    <div class="water_field">
+      <%= water.label :intern ,"収容人数" %><br>
+      <%= water.number_field :intern %>
+    </div>
+    <div class="water_field">
+      <%= water.label :comment ,"コメント" %><br>
+      <%= water.text_area :comment %>
+    </div>
+  <% end %>
   <%= form.submit "施設情報登録" %>
 <% end %>

--- a/app/views/facilities/show.html.erb
+++ b/app/views/facilities/show.html.erb
@@ -41,10 +41,28 @@
   <th>コメント</th>
 </tr>
 <tr>
-  <td><%=sauna.sex%></td>
-  <td><%=sauna.temperature%></td>
-  <td><%=sauna.intern%></td>
-  <td><%=sauna.comment%></td>
+  <td><%= sauna.sex %></td>
+  <td><%= sauna.temperature %></td>
+  <td><%= sauna.intern %></td>
+  <td><%= sauna.comment %></td>
+</tr>
+</table>
+<% end %>
+
+<% @water_baths.each do |water| %>
+<h3>水風呂情報</h3>
+<table>
+<tr>
+  <th>性別</th>
+  <th>温度</th>
+  <th>収容人数</th>
+  <th>コメント</th>
+</tr>
+<tr>
+  <td><%= water.sex %></td>
+  <td><%= water.temperature %></td>
+  <td><%= water.intern %></td>
+  <td><%= water.comment %></td>
 </tr>
 </table>
 <% end %>

--- a/db/migrate/20210803045921_create_water_baths.rb
+++ b/db/migrate/20210803045921_create_water_baths.rb
@@ -1,0 +1,13 @@
+class CreateWaterBaths < ActiveRecord::Migration[5.2]
+  def change
+    create_table :water_baths do |t|
+      t.integer :sex
+      t.integer :temperature
+      t.integer :intern
+      t.string :comment
+      t.references :facility, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_08_03_020449) do
+ActiveRecord::Schema.define(version: 2021_08_03_045921) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -81,7 +81,19 @@ ActiveRecord::Schema.define(version: 2021_08_03_020449) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  create_table "water_baths", force: :cascade do |t|
+    t.integer "sex"
+    t.integer "temperature"
+    t.integer "intern"
+    t.string "comment"
+    t.bigint "facility_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["facility_id"], name: "index_water_baths_on_facility_id"
+  end
+
   add_foreign_key "reviews", "facilities"
   add_foreign_key "reviews", "users"
   add_foreign_key "saunas", "facilities"
+  add_foreign_key "water_baths", "facilities"
 end

--- a/test/fixtures/water_baths.yml
+++ b/test/fixtures/water_baths.yml
@@ -1,0 +1,13 @@
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  sex: 1
+  temperature: 1
+  intern: 1
+  comment: MyString
+
+two:
+  sex: 1
+  temperature: 1
+  intern: 1
+  comment: MyString

--- a/test/models/water_bath_test.rb
+++ b/test/models/water_bath_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class WaterBathTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
### WaterBathテーブルのCRUD機能実装
- 「検索ページ」の「施設登録」部分から「Facility」にネストする形でWaterBath.new/createができる。
- 「検索ページ」の「施設１」の「情報編集」から「Facility」にネストする形でWaterBath.updateができる。
- 「Facility.show」にネストする形で「Sauna.show」を追加

### Facilityテーブルと関連付け
-  「Facility」が削除されたとき「WaterBath」も同時に削除される
-  「Facility」と「WaterBath」の関係は１対多の関係とする