### PR TITLE
RestAreaテーブルのCRUD機能作成 およびFacilityテーブルとの関連付け

### DIFF
--- a/app/controllers/facilities_controller.rb
+++ b/app/controllers/facilities_controller.rb
@@ -9,6 +9,7 @@ class FacilitiesController < ApplicationController
     @facility = Facility.new
     @facility.saunas.build
     @facility.water_baths.build
+    @facility.rest_areas.build
   end
 
   def create
@@ -24,12 +25,14 @@ class FacilitiesController < ApplicationController
     @facility = Facility.find(params[:id])
     @saunas = @facility.saunas
     @water_baths = @facility.water_baths
+    @rest_areas = @facility.rest_areas
   end
 
   def edit
     @facility = Facility.find(params[:id])
     @facility.saunas.build
     @facility.water_baths.build
+    @facility.rest_areas.build
   end
 
   def update
@@ -53,8 +56,14 @@ class FacilitiesController < ApplicationController
                                      :homepage, :business_hours, :holiday,
                                      :fee, :payment, :comment,
                                      saunas_attributes: [
-                                       :id, :sex , :temperature, :intern, :comment],
+                                       :id, :sex, :temperature, :intern, :comment],
                                      water_baths_attributes: [
-                                      :id, :sex , :temperature, :intern, :comment])
+                                      :id, :sex, :temperature, :intern, :comment],
+                                    rest_areas_attributes: [
+                                      :id, :sex, :inside_bath_chair, :inside_deck_chair,
+                                      :inside_relax_chair, :inside_bench, :inside_bench_non_backrest,
+                                      :outside_bath_chair, :outside_deck_chair,
+                                      :outside_relax_chair, :outside_bench, :outside_bench_non_backrest,
+                                      :comment ])
   end
 end

--- a/app/models/facility.rb
+++ b/app/models/facility.rb
@@ -2,6 +2,9 @@ class Facility < ApplicationRecord
   has_many :reviews, dependent: :destroy
   has_many :saunas, dependent: :destroy
   has_many :water_baths, dependent: :destroy
+  belongs_to :rest_area
   accepts_nested_attributes_for :saunas, allow_destroy: true, reject_if: :all_blank
   accepts_nested_attributes_for :water_baths, allow_destroy: true, reject_if: :all_blank
+  accepts_nested_attributes_for :rest_area, allow_destroy: true, reject_if: :all_blank
+
 end

--- a/app/models/facility.rb
+++ b/app/models/facility.rb
@@ -2,9 +2,9 @@ class Facility < ApplicationRecord
   has_many :reviews, dependent: :destroy
   has_many :saunas, dependent: :destroy
   has_many :water_baths, dependent: :destroy
-  belongs_to :rest_area
+  has_many :rest_areas, dependent: :destroy
   accepts_nested_attributes_for :saunas, allow_destroy: true, reject_if: :all_blank
   accepts_nested_attributes_for :water_baths, allow_destroy: true, reject_if: :all_blank
-  accepts_nested_attributes_for :rest_area, allow_destroy: true, reject_if: :all_blank
+  accepts_nested_attributes_for :rest_areas, allow_destroy: true, reject_if: :all_blank
 
 end

--- a/app/models/rest_area.rb
+++ b/app/models/rest_area.rb
@@ -1,0 +1,4 @@
+class RestArea < ApplicationRecord
+  belongs_to :facility
+  enum sex: { "無性別": 0, "男性": 1, "女性": 2 }
+end

--- a/app/views/facilities/_form.html.erb
+++ b/app/views/facilities/_form.html.erb
@@ -81,5 +81,62 @@
       <%= water.text_area :comment %>
     </div>
   <% end %>
+
+  <h2>休憩エリア情報</h2>
+  <%= form.fields_for :rest_areas do |rest| %>
+    <div class="rest_field">
+      <%= rest.label :sex ,"男性" %>
+      <%= rest.radio_button :sex, :"男性" %>
+      <%= rest.label :sex ,"女性" %>
+      <%= rest.radio_button :sex, :"女性" %>
+    </div>
+    <h3>室内</h3>
+    <div class="rest_field">
+      <%= rest.label :inside_bath_chair ,"風呂イス" %><br>
+      <%= rest.number_field :inside_bath_chair %>
+    </div>
+    <div class="rest_field">
+      <%= rest.label :inside_deck_chair ,"デッキチェア" %><br>
+      <%= rest.number_field :inside_deck_chair %>
+    </div>
+    <div class="rest_field">
+      <%= rest.label :inside_relax_chair ,"リラックスチェア" %><br>
+      <%= rest.number_field :inside_relax_chair %>
+    </div>
+    <div class="rest_field">
+      <%= rest.label :inside_bench ,"ベンチ" %><br>
+      <%= rest.number_field :inside_bench %>
+    </div>
+    <div class="rest_field">
+      <%= rest.label :inside_bench_non_backrest ,"背もたれなしベンチ" %><br>
+      <%= rest.number_field :inside_bench_non_backrest %>
+    </div>
+    <h3>室外</h3>
+    <div class="rest_field">
+      <%= rest.label :outside_bath_chair ,"風呂イス" %><br>
+      <%= rest.number_field :outside_bath_chair %>
+    </div>
+    <div class="rest_field">
+      <%= rest.label :outside_deck_chair ,"デッキチェア" %><br>
+      <%= rest.number_field :outside_deck_chair %>
+    </div>
+    <div class="rest_field">
+      <%= rest.label :outside_relax_chair ,"リラックスチェア" %><br>
+      <%= rest.number_field :outside_relax_chair %>
+    </div>
+    <div class="rest_field">
+      <%= rest.label :outside_bench ,"ベンチ" %><br>
+      <%= rest.number_field :outside_bench %>
+    </div>
+    <div class="rest_field">
+      <%= rest.label :outside_bench_non_backrest ,"背もたれなしベンチ" %><br>
+      <%= rest.number_field :outside_bench_non_backrest %>
+    </div>
+    <div class="rest_field">
+      <%= rest.label :comment ,"コメント" %><br>
+      <%= rest.text_area :comment %>
+    </div>
+  <% end %>
+
   <%= form.submit "施設情報登録" %>
 <% end %>

--- a/app/views/facilities/show.html.erb
+++ b/app/views/facilities/show.html.erb
@@ -67,4 +67,47 @@
 </table>
 <% end %>
 
+
+<% @rest_areas.each do |rest| %>
+<h3>休憩エリア情報（室内）</h3>
+<table>
+<tr>
+  <th>性別</th>
+  <th>風呂イス</th>
+  <th>デッキチェア</th>
+  <th>リラックスチェア</th>
+  <th>ベンチ</th>
+  <th>背もたれなしベンチ</th>
+</tr>
+<tr>
+  <td><%= rest.sex %></td>
+  <td><%= rest.inside_bath_chair %></td>
+  <td><%= rest.inside_deck_chair %></td>
+  <td><%= rest.inside_relax_chair %></td>
+  <td><%= rest.inside_bench %></td>
+  <td><%= rest.inside_bench_non_backrest %></td>
+</tr>
+</table>
+
+<h3>休憩エリア情報（室外）</h3>
+<table>
+<tr>
+  <th>性別</th>
+  <th>風呂イス</th>
+  <th>デッキチェア</th>
+  <th>リラックスチェア</th>
+  <th>ベンチ</th>
+  <th>背もたれなしベンチ</th>
+</tr>
+<tr>
+  <td><%= rest.sex %></td>
+  <td><%= rest.outside_bath_chair %></td>
+  <td><%= rest.outside_deck_chair %></td>
+  <td><%= rest.outside_relax_chair %></td>
+  <td><%= rest.outside_bench %></td>
+  <td><%= rest.outside_bench_non_backrest %></td>
+</tr>
+</table>
+<% end %>
+
 <a href="javascript:history.back()">[戻る]</a>

--- a/db/migrate/20210803053310_create_rest_areas.rb
+++ b/db/migrate/20210803053310_create_rest_areas.rb
@@ -1,0 +1,21 @@
+class CreateRestAreas < ActiveRecord::Migration[5.2]
+  def change
+    create_table :rest_areas do |t|
+      t.integer :sex
+      t.integer :inside_bath_chair
+      t.integer :inside_deck_chair
+      t.integer :inside_relax_chair
+      t.integer :inside_bench
+      t.integer :inside_bench_non_backrest
+      t.integer :outside_bath_chair
+      t.integer :outside_deck_chair
+      t.integer :outside_relax_chair
+      t.integer :outside_bench
+      t.integer :outside_bench_non_backrest
+      t.string  :comment
+      t.references :facility, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_08_03_045921) do
+ActiveRecord::Schema.define(version: 2021_08_03_053310) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -31,6 +31,25 @@ ActiveRecord::Schema.define(version: 2021_08_03_045921) do
     t.index ["address"], name: "index_facilities_on_address"
     t.index ["name"], name: "index_facilities_on_name"
     t.index ["prefecture"], name: "index_facilities_on_prefecture"
+  end
+
+  create_table "rest_areas", force: :cascade do |t|
+    t.integer "sex"
+    t.integer "inside_bath_chair"
+    t.integer "inside_deck_chair"
+    t.integer "inside_relax_chair"
+    t.integer "inside_bench"
+    t.integer "inside_bench_non_backrest"
+    t.integer "outside_bath_chair"
+    t.integer "outside_deck_chair"
+    t.integer "outside_relax_chair"
+    t.integer "outside_bench"
+    t.integer "outside_bench_non_backrest"
+    t.string "comment"
+    t.bigint "facility_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["facility_id"], name: "index_rest_areas_on_facility_id"
   end
 
   create_table "reviews", force: :cascade do |t|
@@ -92,6 +111,7 @@ ActiveRecord::Schema.define(version: 2021_08_03_045921) do
     t.index ["facility_id"], name: "index_water_baths_on_facility_id"
   end
 
+  add_foreign_key "rest_areas", "facilities"
   add_foreign_key "reviews", "facilities"
   add_foreign_key "reviews", "users"
   add_foreign_key "saunas", "facilities"

--- a/test/fixtures/rest_areas.yml
+++ b/test/fixtures/rest_areas.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the '{}' from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+# column: value

--- a/test/models/rest_area_test.rb
+++ b/test/models/rest_area_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class RestAreaTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
### RestAreaテーブルのCRUD機能実装
- 「検索ページ」の「施設登録」部分から「Facility」にネストする形でRestArea.new/createができる。
- 「検索ページ」の「施設１」の「情報編集」から「Facility」にネストする形でRestArea.updateができる

### Facilityテーブルと関連付け
-  「Facility」が削除されたとき「RestArea」も同時に削除される
-  「Facility」と「RestArea」の関係は１対１の関係とする