### PR TITLE
FavoriteFacilityテーブルにてUserお気に入り機能の実装

### DIFF
--- a/app/assets/javascripts/favorite_facilities.coffee
+++ b/app/assets/javascripts/favorite_facilities.coffee
@@ -1,0 +1,3 @@
+# Place all the behaviors and hooks related to the matching controller here.
+# All this logic will automatically be available in application.js.
+# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/assets/stylesheets/favorite_facilities.scss
+++ b/app/assets/stylesheets/favorite_facilities.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the favorite_facilities controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/controllers/facilities_controller.rb
+++ b/app/controllers/facilities_controller.rb
@@ -26,6 +26,7 @@ class FacilitiesController < ApplicationController
     @saunas = @facility.saunas
     @water_baths = @facility.water_baths
     @rest_areas = @facility.rest_areas
+    @favorite = current_user.favorite_facilities.find_by(facility_id: @facility.id)
   end
 
   def edit

--- a/app/controllers/favorite_facilities_controller.rb
+++ b/app/controllers/favorite_facilities_controller.rb
@@ -1,0 +1,11 @@
+class FavoriteFacilitiesController < ApplicationController
+  def create
+    favorite = current_user.favorite_facilities.create(facility_id: params[:facility_id])
+    redirect_to facility_path(params[:facility_id]), notice: "さんのブログをお気に入り登録しました"
+  end
+
+  def destroy
+    favorite = current_user.favorite_facilities.find_by(id: params[:id]).destroy
+    redirect_to facility_path(params[:facility_id]), notice: "さんのブログをお気に入り解除しました"
+  end
+end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -11,4 +11,9 @@ class UsersController < ApplicationController
     @reviews = Review.where(user_id: current_user.id)
   end
 
+
+  def favorite_facilities
+    @favorites = FavoriteFacility.where(user_id: current_user.id)
+  end
+
 end

--- a/app/helpers/favorite_facilities_helper.rb
+++ b/app/helpers/favorite_facilities_helper.rb
@@ -1,0 +1,2 @@
+module FavoriteFacilitiesHelper
+end

--- a/app/models/facility.rb
+++ b/app/models/facility.rb
@@ -1,5 +1,6 @@
 class Facility < ApplicationRecord
   has_many :reviews, dependent: :destroy
+  has_many :favorite_facilities, dependent: :destroy
   has_many :saunas, dependent: :destroy
   has_many :water_baths, dependent: :destroy
   has_many :rest_areas, dependent: :destroy

--- a/app/models/favorite_facility.rb
+++ b/app/models/favorite_facility.rb
@@ -1,2 +1,4 @@
 class FavoriteFacility < ApplicationRecord
+  belongs_to :user
+  belongs_to :facility
 end

--- a/app/models/favorite_facility.rb
+++ b/app/models/favorite_facility.rb
@@ -1,0 +1,2 @@
+class FavoriteFacility < ApplicationRecord
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,5 +1,6 @@
 class User < ApplicationRecord
   has_many :reviews, dependent: :destroy
+  has_many :favorite_facilities, dependent: :destroy
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,

--- a/app/views/facilities/show.html.erb
+++ b/app/views/facilities/show.html.erb
@@ -1,6 +1,12 @@
 <h2>facility#show.html</h2>
 <%= link_to '評価・コメントをする' , new_review_path(facility_id: @facility.id) %>
-<%= link_to 'お気に入り追加' , facilities_path %>
+
+<% if @favorite.present? %>
+<%= link_to 'お気に入り解除' , favorite_facility_path(id: @favorite.id,facility_id: @facility.id), method: :delete %>
+<% else %>
+<%= link_to 'お気に入り追加' , favorite_facilities_path(facility_id: @facility.id), method: :post %>
+<% end %>
+
 <%= link_to '情報編集' , edit_facility_path(@facility.id) %>
 <%= link_to '削除', facility_path(@facility.id),method: :delete ,data: { confirm: '削除します' } %>
 

--- a/app/views/users/favorite_facilities.html.erb
+++ b/app/views/users/favorite_facilities.html.erb
@@ -1,0 +1,6 @@
+<h2>user#favorite_facilities.html</h2>
+<h2>自分のお気に入り施設一覧</h2>
+<% @favorites.each do |favorite| %>
+<%= link_to "#{favorite.facility.name}" , facility_path(favorite.facility_id) %>
+<br>
+<% end %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -2,6 +2,8 @@
 <h2>ここはマイページ</h2>
 <%= link_to '評価履歴' , users_review_path %>
 <br>
+<%= link_to 'お気に入り施設' , users_favorite_facilities_path %>
+<br>
 <% if current_user.admin?%>
 <%= link_to '管理者画面へ移動' , rails_admin_path %>
 <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,6 +12,7 @@ Rails.application.routes.draw do
   resources :users
   resources :reviews
   resources :facilities
+  resources :favorite_facilities
   mount RailsAdmin::Engine => '/admin', as: 'rails_admin'
 end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,6 +9,7 @@ Rails.application.routes.draw do
   get '/about',to: 'facilities#about'
   get '/facilities/search',to: 'facilities#search'
   get '/users/review',to: 'users#review'
+  get '/users/favorite_facilities',to: 'users#favorite_facilities'
   resources :users
   resources :reviews
   resources :facilities

--- a/db/migrate/20210803063608_create_favorite_facilities.rb
+++ b/db/migrate/20210803063608_create_favorite_facilities.rb
@@ -1,0 +1,10 @@
+class CreateFavoriteFacilities < ActiveRecord::Migration[5.2]
+  def change
+    create_table :favorite_facilities do |t|
+      t.references :facility, foreign_key: true
+      t.references :user, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_08_03_053310) do
+ActiveRecord::Schema.define(version: 2021_08_03_063608) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -31,6 +31,15 @@ ActiveRecord::Schema.define(version: 2021_08_03_053310) do
     t.index ["address"], name: "index_facilities_on_address"
     t.index ["name"], name: "index_facilities_on_name"
     t.index ["prefecture"], name: "index_facilities_on_prefecture"
+  end
+
+  create_table "favorite_facilities", force: :cascade do |t|
+    t.bigint "facility_id"
+    t.bigint "user_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["facility_id"], name: "index_favorite_facilities_on_facility_id"
+    t.index ["user_id"], name: "index_favorite_facilities_on_user_id"
   end
 
   create_table "rest_areas", force: :cascade do |t|
@@ -111,6 +120,8 @@ ActiveRecord::Schema.define(version: 2021_08_03_053310) do
     t.index ["facility_id"], name: "index_water_baths_on_facility_id"
   end
 
+  add_foreign_key "favorite_facilities", "facilities"
+  add_foreign_key "favorite_facilities", "users"
   add_foreign_key "rest_areas", "facilities"
   add_foreign_key "reviews", "facilities"
   add_foreign_key "reviews", "users"

--- a/test/controllers/favorite_facilities_controller_test.rb
+++ b/test/controllers/favorite_facilities_controller_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class FavoriteFacilitiesControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/fixtures/favorite_facilities.yml
+++ b/test/fixtures/favorite_facilities.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the '{}' from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+# column: value

--- a/test/models/favorite_facility_test.rb
+++ b/test/models/favorite_facility_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class FavoriteFacilityTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
### FavoriteFacilityテーブルでお気に入り機能の実装
- 「User」テーブルと「Facility」テーブルを繋ぐ「FavoriteFacility」テーブルを作成
- facility.showページの「お気に入り追加」を押すとFavorite.createされる
- facility.showページの「お気に入り削除」を押すとFavorite.destroyされる
- マイページにお気に入りのリンクを作成しお気に入り施設の一覧画面が表示される