### PR TITLE
Searchページのレイアウト変更

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -57,6 +57,15 @@ li { list-style: none; }
   text-align: center;
 }
 
+/* facilities#search.html */
+.facility_review{
+  margin: 5px;
+  padding: 5px;
+  width: 80%;
+  background-color: #FFF;
+  border-radius: 10px;
+}
+
 
 /*
  * This is a manifest file that'll be compiled into application.css, which will include all the files

--- a/app/views/facilities/search.html.erb
+++ b/app/views/facilities/search.html.erb
@@ -1,7 +1,5 @@
-<h2>facilities#search.html</h2>
 <%= link_to '施設登録' , new_facility_path %>
 <br>
-
 <%= form_with url: facilities_path do |f| %>
   <div class="search_field">
     <%= f.label :address ,"キーワード" %>
@@ -29,31 +27,37 @@
   </div>
   <div class="search_field">
     <%= f.label :sex, '性別' %>
-    <%= f.label :sex ,"男性" %>
     <%= f.radio_button :sex, :"男性" %>
-    <%= f.label :sex ,"女性" %>
+    <%= f.label :sex ,"男性" %>
     <%= f.radio_button :sex, :"女性" %>
+    <%= f.label :sex ,"女性" %>
   </div>
   <%= f.submit "検索_未実装",name: :search%>
 <% end %>
-
-<br>
-<br>
+<h3>最近評価された施設</h3>
+<% @reviews.each do |review| %>
+  <div class="facility_review">
+  <%= link_to facility_path(review.facility.id) do %>
+    <%= review.facility.name %>
+    <%= review.facility.prefecture + review.facility.address %>
+  <% end %>
+  <br>
+  <%= link_to review_path(review.id) do %>
+    <%= "#{review.user.name}さんの評価："%>
+    <%= "★" * (review.dry + review.light + review.wide) %><br>
+    <%= "#{review.comment}" %>
+  <% end %>
+  </div>
+<% end %>
 <h3>最近更新された施設</h3>
 <% @facilities.each do |facility| %>
-<%= link_to facility.name , facility_path(facility.id) %>
-<br>
+  <%= link_to facility_path(facility.id) do %>
+    <%= facility.name %>
+    <%= facility.prefecture + facility.address %>
+  <% end %>
+  <br>
 <% end %>
 <br>
-<h3>最近投稿された口コミ</h3>
-<% @reviews.each do |review| %>
-<%= link_to "#{review.user.name}さんの#{review.facility.name}への口コミ" , review_path(review.id) %>
-<br>
-<% end %>
-<p>もっと見る</p>
-<br>
-<br>
-
 <h2>以下、未実装</h2>
 <h3>都道府県</h3>
 <%= link_to '北海道' , facilities_path %>

--- a/app/views/facilities/search.html.erb
+++ b/app/views/facilities/search.html.erb
@@ -1,11 +1,42 @@
 <h2>facilities#search.html</h2>
 <%= link_to '施設登録' , new_facility_path %>
 <br>
-<p>キーワード</p>
-<p>設備</p>
-<p>環境</p>
-<br>
-<%= link_to '詳細検索 (未実装)' , facilities_path %>
+
+<%= form_with url: facilities_path do |f| %>
+  <div class="search_field">
+    <%= f.label :address ,"キーワード" %>
+    <%= f.text_field :address ,placeholder:"かるまる、池袋、東京"%>
+  </div>
+  <div class="search_field">
+    <%= f.label :rest_area, '設備' %>
+    <%= f.check_box :bath_chair %>
+    <%= f.label :bath_chair, '風呂イス' %>
+    <%= f.check_box :deck_chair %>
+    <%= f.label :deck_chair, 'デッキチェア' %>
+    <%= f.check_box :relax_chair %>
+    <%= f.label :relax_chair, 'リラックスチェア' %>
+    <%= f.check_box :bench %>
+    <%= f.label :bench, 'ベンチ（背もたれあり）' %>
+    <%= f.check_box :bench_non_backrest %>
+    <%= f.label :bench_non_backrest, 'ベンチ（背もたれなし）' %>
+  </div>
+  <div class="search_field">
+    <%= f.label :rest_area, '環境' %>
+    <%= f.check_box :indoor %>
+    <%= f.label :indoor, '室内' %>
+    <%= f.check_box :outdoor %>
+    <%= f.label :outdoor, '室外' %>
+  </div>
+  <div class="search_field">
+    <%= f.label :sex, '性別' %>
+    <%= f.label :sex ,"男性" %>
+    <%= f.radio_button :sex, :"男性" %>
+    <%= f.label :sex ,"女性" %>
+    <%= f.radio_button :sex, :"女性" %>
+  </div>
+  <%= f.submit "検索_未実装",name: :search%>
+<% end %>
+
 <br>
 <br>
 <h3>最近更新された施設</h3>


### PR DESCRIPTION
### 暫定での体裁修正で提出

#### 検索部分レイアウト
- ワイヤーフレームに少しでも似せること
- 詳細検索部分は"form_with"を使用すること
- 「詳細検索」の飛び先は現状rootに設定すること

#### 評価された施設部レイアウト
#### 施設名
##### ●●さんの評価　★★★
##### コメント内容