### PR TITLE
Fasility.new画面で「Sauna」「WaterBath」の動的なフォーム追加の機能実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,9 @@ gem 'devise-i18n'
 gem 'rails_admin'
 gem 'cancancan'
 
+gem 'cocoon'
+gem 'jquery-rails'
+
 gem 'seed-fu'
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '~> 5.2.5'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -70,6 +70,7 @@ GEM
     chromedriver-helper (2.1.1)
       archive-zip (~> 0.10)
       nokogiri (~> 1.8)
+    cocoon (1.2.15)
     coffee-rails (4.2.2)
       coffee-script (>= 2.2.0)
       railties (>= 4.0.0)
@@ -271,10 +272,12 @@ DEPENDENCIES
   cancancan
   capybara (>= 2.15)
   chromedriver-helper
+  cocoon
   coffee-rails (~> 4.2)
   devise
   devise-i18n
   jbuilder (~> 2.5)
+  jquery-rails
   letter_opener_web
   listen (>= 3.0.5, < 3.2)
   pg (>= 0.18, < 2.0)

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -13,4 +13,6 @@
 //= require rails-ujs
 //= require activestorage
 //= require turbolinks
+//= require jquery
+//= require cocoon
 //= require_tree .

--- a/app/controllers/facilities_controller.rb
+++ b/app/controllers/facilities_controller.rb
@@ -40,7 +40,7 @@ class FacilitiesController < ApplicationController
     @facility = Facility.find(params[:id])
     @facility.saunas.build
     @facility.water_baths.build
-    @facility.rest_areas.build
+    @facility.rest_areas.build if @facility.rest_areas[0].nil?
   end
 
   def update

--- a/app/views/facilities/_form.html.erb
+++ b/app/views/facilities/_form.html.erb
@@ -38,49 +38,29 @@
   </div>
   <%= form.submit "施設情報登録" %>
 
-  <h2>サウナ情報</h2>
-  <%= form.fields_for :saunas do |sauna| %>
-    <div class="sauna_field">
-      <%= sauna.label :sex ,"男性" %>
-      <%= sauna.radio_button :sex, :"男性" %>
-      <%= sauna.label :sex ,"女性" %>
-      <%= sauna.radio_button :sex, :"女性" %>
-    </div>
-    <div class="sauna_field">
-      <%= sauna.label :temperature ,"温度" %><br>
-      <%= sauna.number_field :temperature %>
-    </div>
-    <div class="sauna_field">
-      <%= sauna.label :intern ,"収容人数" %><br>
-      <%= sauna.number_field :intern %>
-    </div>
-    <div class="sauna_field">
-      <%= sauna.label :comment ,"コメント" %><br>
-      <%= sauna.text_area :comment %>
-    </div>
-  <% end %>
+  <div class="sauna">
+    <%= form.fields_for :saunas do |sauna| %>
+      <% render "sauna_fields",f: sauna %>
+    <% end %>
+  </div>
+  <div id="detail-association-insertion-point"></div>
+  <%= link_to_add_association 'サウナ追加', form, :saunas,
+    data: {
+      association_insertion_node: '#detail-association-insertion-point',
+      association_insertion_method: 'append' }
+   %>
 
-  <h2>水風呂情報</h2>
+<div class="water_bath">
   <%= form.fields_for :water_baths do |water| %>
-    <div class="water_field">
-      <%= water.label :sex ,"男性" %>
-      <%= water.radio_button :sex, :"男性" %>
-      <%= water.label :sex ,"女性" %>
-      <%= water.radio_button :sex, :"女性" %>
-    </div>
-    <div class="water_field">
-      <%= water.label :temperature ,"温度" %><br>
-      <%= water.number_field :temperature %>
-    </div>
-    <div class="water_field">
-      <%= water.label :intern ,"収容人数" %><br>
-      <%= water.number_field :intern %>
-    </div>
-    <div class="water_field">
-      <%= water.label :comment ,"コメント" %><br>
-      <%= water.text_area :comment %>
-    </div>
+    <% render "water_bath_fields",f: water %>
   <% end %>
+</div>
+<div id="detail-association-insertion-point"></div>
+<%= link_to_add_association '水風呂追加', form, :water_baths,
+  data: {
+    association_insertion_node: '#detail-association-insertion-point',
+    association_insertion_method: 'append' }
+ %>
 
   <h2>休憩エリア情報</h2>
   <%= form.fields_for :rest_areas do |rest| %>

--- a/app/views/facilities/_sauna_fields.html.erb
+++ b/app/views/facilities/_sauna_fields.html.erb
@@ -1,0 +1,21 @@
+<div class="nested_fields">
+<h2>サウナ情報</h2>
+  <div class="sauna_field">
+    <%= f.label :sex ,"男性" %>
+    <%= f.radio_button :sex, :"男性" %>
+    <%= f.label :sex ,"女性" %>
+    <%= f.radio_button :sex, :"女性" %>
+  </div>
+  <div class="sauna_field">
+    <%= f.label :temperature ,"温度" %><br>
+    <%= f.number_field :temperature %>
+  </div>
+  <div class="sauna_field">
+    <%= f.label :intern ,"収容人数" %><br>
+    <%= f.number_field :intern %>
+  </div>
+  <div class="sauna_field">
+    <%= f.label :comment ,"コメント" %><br>
+    <%= f.text_area :comment %>
+  </div>
+</div>

--- a/app/views/facilities/_water_bath_fields.html.erb
+++ b/app/views/facilities/_water_bath_fields.html.erb
@@ -1,0 +1,21 @@
+<div class="nested_fields">
+  <h2>水風呂情報</h2>
+    <div class="water_field">
+      <%= f.label :sex ,"男性" %>
+      <%= f.radio_button :sex, :"男性" %>
+      <%= f.label :sex ,"女性" %>
+      <%= f.radio_button :sex, :"女性" %>
+    </div>
+    <div class="water_field">
+      <%= f.label :temperature ,"温度" %><br>
+      <%= f.number_field :temperature %>
+    </div>
+    <div class="water_field">
+      <%= f.label :intern ,"収容人数" %><br>
+      <%= f.number_field :intern %>
+    </div>
+    <div class="water_field">
+      <%= f.label :comment ,"コメント" %><br>
+      <%= f.text_area :comment %>
+    </div>
+</div>


### PR DESCRIPTION
### Fasility.new画面で「Sauna」「WaterBath」の動的なフォーム追加の機能実装
- Gem 'coccon'を使用して動的否フォーム追加を実装
- Facility.edit時に休憩エリア情報は一つ表示される

~~Facility.edit時に既存の「Sauna」「WaterBath」テーブルを削除できること~~
レイアウト変更時に変更する可能性があるので未修正