### PR TITLE
ヘッダーのメニューをメガメニュー化

### DIFF
--- a/app/assets/stylesheets/facilities.scss
+++ b/app/assets/stylesheets/facilities.scss
@@ -144,10 +144,9 @@ input:checked + label img.chair_image {
   position: relative;
   margin-left: auto;
   margin-right: 20%;
-
   border-top: 1px solid #88A3A9;
   border-bottom: 3px solid #88A3A9;
-  border-left: 1px solid #88A3A9;  
+  border-left: 1px solid #88A3A9;
   border-right: 3px solid #88A3A9;
 }
 .explain .chack_box{

--- a/app/assets/stylesheets/layout.scss
+++ b/app/assets/stylesheets/layout.scss
@@ -75,29 +75,71 @@ li { list-style: none; }
   border-radius: 10px;
 }
 
-
 .top_menu_right{
   float: right;
-  margin-top: 15px;
 }
 .top_menu_right li{
   float: left;
   width: auto;
+  margin-top: 15px;
 }
-.top_menu_right li a{
+.top_menu_right li a ,.top_menu_right li label{
+  display: inline;
+  color: #0d6efd;
   background-color: #fafafa;
   border: solid #f0f0f0;
   border-radius: 5px;
   padding: 15px;
-  margin: 5px;
+  margin: 0 10px;
   transition: 0.3s;
+  text-decoration: none;
 }
 .top_menu_right li a:hover{
   background-color: #d0d0d0;
-  border-radius: 5px;
-  padding: 15px;
-  margin: 5px;
 }
+// ############
+
+.menu_potision{
+  position: relative;
+}
+
+.menu_potision a{
+
+}
+
+.top_menu_right .chack_box{
+  display: none;
+}
+
+input[type="checkbox"]:checked + #memu_popup{
+  display:block;
+  animation: fadein 0.3s;
+}
+
+#memu_popup{
+  display: none;
+  width: 240px;
+  padding: 10px;
+  background-color: #FFF;
+  border: 5px double #ECE8F8;
+  border-radius: 10px;
+  position: absolute;
+  top : 50px;
+  right: 0px;
+  opacity: 0.9;
+  z-index: 10;
+
+}
+
+.menu{
+    text-decoration: none;
+  width: 240px;
+    font-size: 20px;
+}
+
+
+// ############
+
 
 
 .footer {

--- a/app/views/facilities/search.html.erb
+++ b/app/views/facilities/search.html.erb
@@ -1,6 +1,4 @@
-<% if user_signed_in? %>
-<%= link_to '施設登録' , new_facility_path %>
-<% end %>
+
 <div class="search_container">
   <h3>検索</h3>
   <%= search_form_for @chair, url: facilities_path do |f| %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -17,6 +17,7 @@
         <%= image_tag "logo.png" , class:"logo"%>
       <% end %>
     <div class="header_container">
+
     <ul class="top_menu_left">
       <li><%= link_to 'このサイトについて' , about_path %></li>
       <li><%= link_to '検索する' , facilities_search_path %></li>
@@ -24,15 +25,33 @@
         <li><%= "こんにちは、#{current_user.name} さん" %></li>
       <% end %>
     </ul>
+
     <ul class="top_menu_right">
     <% if user_signed_in? %>
-      <li><%= link_to 'ログアウト' , destroy_user_session_path ,method: :delete%></li>
-      <li><%= link_to 'マイページ' , user_path(1) %></li>
-      <% else %>
+    <div class="menu_potision">
+      <li><%= label :memu,"マイメニュー" , for:"memu" %></li>
+      <%= check_box_tag "memu" ,"",false,class:"chack_box"%>
+      <label id="memu_popup" for="memu">
+        <%= link_to '評価履歴' , users_review_path ,class:"menu"%><br>
+        <%= link_to 'お気に入り施設' , users_favorite_facilities_path ,class:"menu"%><br>
+        <%= link_to '閲覧履歴(未実装)' ,facilities_search_path,class:"menu"%><br>
+        <%= link_to 'アカウント情報変更' , edit_user_registration_path ,class:"menu"%><br><hr>
+        <% if user_signed_in? %>
+          <%= link_to '施設登録' , new_facility_path ,class:"menu"%><br>
+        <% end %>
+        <% if current_user.admin?%>
+          <%= link_to 'サイト管理画面' , rails_admin_path ,class:"menu"%><br><hr>
+        <% end %>
+        <%= link_to 'ログアウト' , destroy_user_session_path ,method: :delete,class:"menu"%>
+      </label>
+    </div>
+    <% else %>
       <li><%= link_to 'ログイン' , new_user_session_path %></li>
       <li><%= link_to '新規登録' , new_user_registration_path %></li>
     <% end %>
     </ul>
+
+
 </div>
     </header>
     <% flash.each do |key, value| %>


### PR DESCRIPTION
以下の順で表示させた
- 評価履歴
- お気に入り施設
- 閲覧履歴(未実装)
- プロフィール編集
===
- 施設登録
- サイト管理画面
===
- ログアウト